### PR TITLE
created variance and coefficient of variation arrests feature.

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -11,7 +11,7 @@ distdir: dists  # Where to put them
 # Comment fields       #
 ########################
 model_comment: ''
-batch_comment: 'test batch comment'
+batch_comment: ''
 
 ########################
 # Type of Experiment   #
@@ -65,6 +65,8 @@ try_feature_sets_by_group: False  # Turn on if you want the code to try removing
 
 officer_features:
     TimeGatedDummyFeature: False # Time gated dummy feature. Example feature.
+    ArrestMonthlyVariance: True
+    ArrestMonthlyCOV: True
     AcademyScore: True # Performance score at the police academy.
     DivorceCount: True # Number of total divorces in this officer's past.
     MilesFromPost: True # Number of miles to post.


### PR DESCRIPTION
Populates two new features: `ArrestMonthlyVariance` and `ArrestMonthlyCOV`.  The first is the month-by-month variance of arrest count, and the second is the month-by-month coefficient of variation (standard deviation divided by the mean).  Both are time-gated features.  The COV feature imputes a 0 when the mean is 0 (standard practice, usually, since a 0 mean in a strictly positive set means the entire set has no variation).
