### PR TITLE
Added query_sustained_and_unknown_outcome to query for allegations th…

### DIFF
--- a/eis/dataset.py
+++ b/eis/dataset.py
@@ -444,6 +444,9 @@ class FeatureLoader():
         if officer_labels["SustainedForceAllegations"]:
             queries_for_adverse.append( query_force + " AND " +  query_sustained )
 
+        if officer_labels["SustainedandUnknownForceAllegations"]:
+            queries_for_adverse.append( query_force + " AND " +  query_sustained_and_unknown_outcome )
+
         if officer_labels["AllAllegations"]:
             queries_for_advsere.append( query_all )
 

--- a/example_officer_config.yaml
+++ b/example_officer_config.yaml
@@ -66,14 +66,19 @@ officer_labels:                     # note: the labels below are combined with a
     include_all_active: True        # include all oficcers who made an arrest or stop during the specified period.
     AllAllegations: False           # all allegations.
     SustainedAllegations: False     # all sustained allegations.
+    SustainedandUnknownOutcomeAllegations: False     # all sustained and unknown outcome allegations.
     MajorAllegations: True # all allegations of type: {accident, bias, insubordination, gift policy, handling of civs, substance abuse, harrassment, force}
     SustainedMajorAllegations: True  # all allegations of major type that were sustained.
+    SustainedUnknownMajorAllegations: True  # all allegations of major type that were sustained or had an unknown outcome.
     MinorAllegations: False # all allegations of type: {appearance, standard procedures, traffic laws, tardiness, equipment, quality, conditions of employment }
     SustainedMinorAllegations: False # all allegations of minor type that were sustained.
+    SustainedUnkownMinorAllegations: False # all allegations of minor type that were sustained or had an unknown outcome.
     ForceAllegations: False         # all force allegations.
     SustainedForceAllegations: False # all sustained force allegations.
+    SustainedandUnknownForceAllegations: False # all sustained and unknown outcome force allegations.
     UnknownAllegations: False # allegations categorized as "unknown".
     SustainedUnknownAllegations: False # allegations categorized as "unknown" and sustained.
+    SustainedUnknownUnknownAllegations: False # allegations categorized as "unknown" with a final out come that is sustained or unknown
 
 ########################
 # Feature selection    #


### PR DESCRIPTION
…at are sustained or have an unknown outcome. This makes for some awkward names for queries that look for sustained and unknown outcomes on unknown types of violations. 

This might not be the best way to make these labels, but it is as in-line with what we've been doing as I could think of.
