### PR TITLE
Updating and restructuring documentation

### DIFF
--- a/docs/nashville_staging_population_and_management.md
+++ b/docs/nashville_staging_population_and_management.md
@@ -1,0 +1,51 @@
+# Managing staging schemas
+
+The `staging` schema should not be in flux or have changes made on the fly. Instead a development schema (_eg_ `staging_dev`) should be used to test new population code. This allows the feature generation code and model code to rely on what is in the `staging` schema.
+
+When the development staging schema is in a (reliable|stable) state, it should be moved to `staging` and then the development staging schema should be recreated (with the Luigi commands below).
+
+You must have a credentials file called `luigi.cfg` for any of the luigi scripts to run. Because these luigi scripts are located in both the `police-eis` and `police-eis-private` repositories you will need two copies: one at `police-eis/schemas/luigi.cfg` and another at `police-eis-private/schemas/luigi.cfg`. The form of this credentials file is given in an example file `luigi_example.cfg`. Use the same format here, but with your credentials to allow luigi to connect to the postgres database.
+
+## Repopulating staging_dev without touching staging
+
+To drop and recreate the entire `staging_dev` schema only, run the following postgres commands:
+
+```
+DROP SCHEMA IF EXISTS staging_dev CASCADE;
+CREATE SCHEMA staging_dev;
+```
+
+If you made edits to an existing table population script, and want to test it on this table alone, use:
+
+```
+TRUNCATE TABLE staging_dev.table_name;
+```
+
+to drop the values from just that table.
+
+## Move staging_dev to staging
+
+To move the `staging_dev` schema to `staging` issue the following postgres commands. It will also create a new, empty `staging_dev` schema that will then be populated in the next step.
+
+```
+DROP SCHEMA IF EXISTS staging CASCADE;
+ALTER SCHEMA staging_dev RENAME TO staging;
+CREATE SCHEMA staging_dev;
+```
+
+## Rerun luigi to create and populate the `staging_dev` schema
+
+Run the following commands (in the `police-eis/schemas/` directory) to create the staging table structure and populate lookup tables. Before running Luigi, confirm that you have the correct credentials located in the file `police-eis/schemas/luigi.cfg ` an example of the format for the credentials are given in `luigi_example.cfg`.
+
+```
+PYTHONPATH='' luigi --module setupStaging PopulateLookupTables --table-file ./populate_tables/lookup/lookup_tables.yaml --schema staging_dev --CreateAllStagingTables-create-tables-directory ./create_tables  --local-scheduler
+```
+
+After the staging schema is created, run the following commands (in the `[police-eis/]police-eis-private/schemas/`<sup id="a1">[1](#f1)</sup> directory) to insert the stored procedures and populate the tables with all available data. Before running Luigi, confirm that you have the correct credentials located in the file `[police-eis/]police-eis-private/schemas/luigi.cfg ` an example of the format for the credentials are given in `luigi_example.cfg`.
+
+```
+PYTHONPATH='' luigi --module populateStagingFromMNPD PopulateStoredProcedures --schema staging_dev --local-scheduler
+PYTHONPATH='' luigi --module populateStagingFromMNPD PopulateAllStagingTables --schema staging_dev --populate-tables-directory ./populate_tables/mnpd --local-scheduler
+```
+<hr/>
+<b id="f1"><sup>1</sup></b> The `[police-eis/]` in the path is to show the canonical location of the `police-eis-private` repo being in the root directory of the `police-eis` repo. If it is located elsewhere in your setup, you should use that directory instead. [↩](#a1)

--- a/docs/repositories_dependencies_and_pipeline.md
+++ b/docs/repositories_dependencies_and_pipeline.md
@@ -1,0 +1,71 @@
+# Repositories, dependencies, and pipeline management
+
+This document describes the general structure and process for the full `police-eis` project.
+
+## What are the repos?
+
+There are a number of repositories that are and have been used in the course of developing the police early intervention system. This document is designed to describe the purpose and content of each. There is [detailed documentation about each of the repositories used.](./repository_documentation.md)
+
+### How do I get them?
+
+For the `police-eis` repository, simply run:
+
+`git clone --recursive https://github.com/dssg/police-eis.git`
+
+For the `police-eis-private` repository, change your directory to be in the root level of the `police-eis` repository, and then run:
+
+`git clone --recursive https://github.com/dssg/police-eis-private.git`
+
+The `--recursive` flag is important because it will make sure to clone any submodules that are included in the repositories (currently this is only [pg_tools](https://github.com/jonkeane/pg_tools)).
+
+## Dependencies
+
+### Drake
+
+### Python 3.4+
+#### Packages
+
+### Luigi
+
+#### pg_tools
+[pg_tools](https://github.com/jonkeane/pg_tools) needs to exist in the repositories when you run any of the luigi population scripts. If you cloned the repositories with the `--recursive` flag, you should have them already. If you don't already have them, or you're getting errors that luigi cannot find pg_tools, you can try recloning pg_tools with the following commands:
+
+```
+cd [path to police-eis repo]\schemas\pg_tools
+git submodule init
+git submodule update
+```
+
+and for the `police-eis-private` repo:
+
+```
+cd [path to police-eis repo]\police-eis-private\schemas\pg_tools
+git submodule init
+git submodule update
+```
+
+## Pipeline
+
+### Raw to ETL
+
+We use Drake to transfer the raw data from the department to the ETL schema. To run this process use the following command:
+
+`The right drake command here.`
+
+### ETL to staging
+
+We use luigi to move data from the ETL schema to the staging schema. [Full documentation for this process (including repopulation) is available.](nashville_staging_population_and_management.md)
+
+Much, but not all, of the ETL to staging process has been automated with a bash script called ['run_luigi.sh' in the `police-eis/schemas/` directory.](../schemas/run_luigi.sh)
+
+### Staging to features
+
+To generate features, set the configuration of features (and labels) in a configuration file that has the same form  as `example_officer_config.yaml`. And then from the `police-eis` directory, run:
+
+`python -m eis.run [configuration file name] --buildfeatures`
+
+### Features to results
+
+Once the features have been built, you can run all of the models with:
+
+`python -m eis.run [configuration file name]`

--- a/docs/repository_documentation.md
+++ b/docs/repository_documentation.md
@@ -1,0 +1,31 @@
+# [DSSG](https://dssg.uchicago.edu "Data Science for Social Good") and [DSaPP](https://dsapp.uchicago.edu/ "The Center for Data Science and Public Policy") Police Early Intervention System repository structure
+
+There are a number of repositories that are and have been used in the course of developing the police early intervention system. This document is designed to describe the purpose and content of each.
+
+## General pipeline
+The general pipeline for data is as follows.
+
+![Process](docs/tableProces.png)
+
+## [`police-eis`](https://github.com/dssg/police-eis)
+This is the main open source, public repository for the Police EIS project. This code generally operates on the pipeline from the staging schema on.
+
+It includes:
+* SQL scripts that fully define the Common Police Schema
+* Code (currently implemented with [Luigi](https://github.com/spotify/luigi)) to create an empty schema that conforms to the Common Police Schema, as well as populates all relevant lookup tables.
+* Code to generate features from a populated Common Police Schema database. The `features` schema is created automatically in the feature generation process.
+* Code to run a number of machine learning models on these features.
+* Code to evaluate, store, and visualize the results from these models. The `results` schema is created and populated automatically in the model running process.
+* A web application to inspect select metrics of the models that are stored in the `results` schema.
+
+## [`police-eis-private`](https://github.com/dssg/police-eis-private)
+This is the repository that contains department-specific information for the process of going from raw department data to `ETL` schemas and then the population from the (department specific) `ETL` schemas to the `staging` schema. Currently this repository is private because it includes references to specific column names in the raw data from the departments.
+
+It includes:
+* [Drake](https://www.factual.com/blog/introducing-drake-a-kind-of-make-for-data) scripts to load raw data into `ETL` schemas (or other processes that are department specific).
+* SQL scrips and some python cleanup scripts that transform data from `ETL` schemas to then be populated into the `staging` schemas
+
+This repository should sit in the root directory of the [`police-eis`](https://github.com/dssg/police-eis) repository described above.
+
+## [`police`](https://github.com/dssg/police)
+This repsoitory is mostly a hold over from previous iterations of the project. It does, however, contain some exploratory data analysis code that includes some department-specific information. This repository should be reserved for exploratory data analysis or historical code if at all possible. It should not include any pipeline code if at all possible.


### PR DESCRIPTION
I have added documentation for the overall project workflow (repositories_dependencies_and_pipeline), moved repository documentation and staging population and management documentation from `police-eis-private` to `police-eis`.

The overall project workflow (repositories_dependencies_and_pipeline.md) is half skeleton and half filled in. Feel free to add to it as we come across parts that haven't been documented already (ie my clever not-accurate drake command to run drake).

The main purpose of this is to make sure that we have fully documented all of the steps that were put together in that bash script that was pulled in earlier. This way, if the script fails, we know what is supposed to happen at each step.
