### PR TITLE
Write correct officer ids to predictions table

### DIFF
--- a/eis/feature_loader.py
+++ b/eis/feature_loader.py
@@ -257,6 +257,9 @@ class FeatureLoader():
             else:
                  complete_df = complete_df.merge(table, on=['officer_id','as_of_date'], how='left')
 
+		# Set index
+		complete_df = complete_df.set_index('officer_id')		
+
         # Zero imputation
         complete_df.fillna(0, inplace=True)
 

--- a/schemas/create_schemas/CREATE-SCHEMA-results.sql
+++ b/schemas/create_schemas/CREATE-SCHEMA-results.sql
@@ -32,6 +32,7 @@ CREATE TABLE results.models (
   train_end_time    TIMESTAMP,
   experiment_hash   TEXT REFERENCES results.experiments (experiment_hash)
 );
+CREATE INDEX ON results.models (train_end_time)
 
 -- predictions corresponding to each model.
 CREATE TABLE results.predictions (


### PR DESCRIPTION
Updated the index before passing to metta
Now stores the correct index in matrices generated by metta
Matrices passed to triage for predictions will have correct entity id